### PR TITLE
Serve compressed non-root index.html files when filename is omitted

### DIFF
--- a/pkg.go
+++ b/pkg.go
@@ -70,8 +70,8 @@ func Handler(z *zip.Reader) http.Handler {
 		}
 
 		key := strings.TrimPrefix(r.URL.Path, "/")
-		if key == "" {
-			key = "index.html"
+		if key == "" || strings.HasSuffix(key, "/") {
+			key += "index.html"
 		}
 		i, ok := m[key]
 		if !ok {


### PR DESCRIPTION
This PR allows zipserver to serve compressed index pages on non-root directories.